### PR TITLE
Check for grandchild roles before recursing into grandchildren.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 West Midlands Fire Service
+Copyright (c) 2018, 2024 West Midlands Fire Service
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -108,5 +108,5 @@ speed.
 Bug reports and pull requests are welcome on GitHub. Please be aware of our [Code of Conduct](https://github.com/wmfs/j2112/blob/master/CODE_OF_CONDUCT.md)
 
 ## <a name="license"></a>License
-Licensed under the terms of the [MIT license](https://github.com/wmfs/j2112/blob/master/LICENSE). Copyright (c) 2018 West Midlands Fire Service
+Licensed under the terms of the [MIT license](https://github.com/wmfs/j2112/blob/master/LICENSE). Copyright (c) 2018, 2024 West Midlands Fire Service
 

--- a/lib/j2119/node_validator.js
+++ b/lib/j2119/node_validator.js
@@ -64,6 +64,7 @@ class NodeValidator {
     // only objects & arrays have grand children
     // find inheritance-based roles for that field
     const grandchildRoles = this.parser.findGrandchildRoles(roles, name)
+    if (!grandchildRoles.length) return 
     if (this.parser.allowsAnyField(grandchildRoles)) return
 
     const gcIndex = Array.isArray(childNode) ? i => `[${i}]` : i => `.${i}`


### PR DESCRIPTION
Hi @meenahoda :slightly_smiling_face: 

I've been looking at updating @wmfs/statelint, and that's triggered a long dormant bug in this package. When walking down a deeply nested state machine, we shouldn't try and check the grandchilden that have no roles.

This is was fixed back in 2019(!) in the Awslabs original
  https://github.com/awslabs/j2119/commit/e8c0caf1643631b8ee0f747e40de0b64aafcb771
and this PR aligns the @wmfs code with that change. 


